### PR TITLE
Update to Visual Studio 2017, working right ouf the box with the VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,10 @@ https://developer.microsoft.com/en-us/windows/downloads/virtual-machines
 
 and create two VMs.
 
-The newer VM images comes with Visual Studio 2017, but this is
-currently not compatible with Kernel Development. At the moment, the
-correct version to use is Visual Studio 2015 update 3. You can
-download and install it for free. But it can be a challenge to find as
-Microsoft hides it well. They also put VCredist 2008, 2012, 2013 and
-2017 on there but skipped 2015 for some reason. They dropped the ball
-that day. You will have to use Add/Remove Programs to uninstall 2017
-version before you can install 2015.
-
 * Host (running Visual Studio and Kernel Debugger)
 * Target (runs the compiled kernel module)
+
+The VM images comes with Visual Studio 2017, which we use to compile the driver. 
 
 It is recommended that the VMs are placed on static IP, as they can
 change IP with all the crashes, and you have to configure the remote
@@ -28,7 +21,10 @@ Go download the Windows Driver Kit 10
 
 https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit
 
-and install on both VMs. You will need both the SDK and WDK.
+and install on both VMs. You will need both the SDK and WDK:
+Download the SDK with the Visual Studio 2017 community edition first and install it.
+It will update the already installed Visual Studio.
+Then install the WDK. At the end of the installer, allow it to install the Visual Studio extension.
 
 
 On Target VM, complete the guide specified here, under
@@ -43,9 +39,9 @@ C:\Program Files (x86)\Windows Kits\10\Remote\x64\WDK Test Target Setup x64-x64_
 * reboot Target VM
 
 
-On the Host VM, continue the guide to configure Visual Studio 2015.
+On the Host VM, continue the guide to configure Visual Studio 2017.
 
-* Load Visual Studio 2015, there is no need to load the project yet.
+* Load Visual Studio 2017, there is no need to load the project yet.
 * Menu > Driver > Test > Configure Devices
 * Click "Add New Device"
 * In "Display name:" enter "Target"
@@ -121,7 +117,7 @@ Run the compiled Target
 * Compile solution
 * Menu > Debug > Start Debugging (F5)
 
-wait a while, for VS15 to deplay the .sys file on Target and start it.
+wait a while, for VS2017 to diplay the .sys file on Target and start it.
 
 
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Run the compiled Target
 * Compile solution
 * Menu > Debug > Start Debugging (F5)
 
-wait a while, for VS2017 to diplay the .sys file on Target and start it.
+wait a while, for VS2017 to deploy the .sys file on Target and start it.
 
 
 

--- a/ZFSin/ZFSin.vcxproj
+++ b/ZFSin/ZFSin.vcxproj
@@ -42,7 +42,7 @@
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>ZFSin</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/cmd/zfs/zfs/zfs.vcxproj
+++ b/ZFSin/zfs/cmd/zfs/zfs/zfs.vcxproj
@@ -47,7 +47,7 @@
     <ProjectGuid>{D923B8A4-5161-4E28-9E69-D3193114DAC4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>zfs</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/cmd/zpool/zpool/zpool.vcxproj
+++ b/ZFSin/zfs/cmd/zpool/zpool/zpool.vcxproj
@@ -48,7 +48,7 @@
     <ProjectGuid>{D588961B-6501-4259-AC02-EAD1B465EF89}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>zpool</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libavl/libavl/libavl.vcxproj
+++ b/ZFSin/zfs/lib/libavl/libavl/libavl.vcxproj
@@ -46,7 +46,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libavl</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libefi/libefi/libefi.vcxproj
+++ b/ZFSin/zfs/lib/libefi/libefi/libefi.vcxproj
@@ -51,7 +51,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libefi</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libicp/libicp/libicp.vcxproj
+++ b/ZFSin/zfs/lib/libicp/libicp/libicp.vcxproj
@@ -79,7 +79,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libicp</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libnvpair/libnvpair/libnvpair.vcxproj
+++ b/ZFSin/zfs/lib/libnvpair/libnvpair/libnvpair.vcxproj
@@ -58,7 +58,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libnvpair</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libshare/libshare/libshare.vcxproj
+++ b/ZFSin/zfs/lib/libshare/libshare/libshare.vcxproj
@@ -48,7 +48,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libshare</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libspl/libspl/libspl.vcxproj
+++ b/ZFSin/zfs/lib/libspl/libspl/libspl.vcxproj
@@ -69,7 +69,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libspl</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libunicode/libunicode/libunicode.vcxproj
+++ b/ZFSin/zfs/lib/libunicode/libunicode/libunicode.vcxproj
@@ -47,7 +47,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libunicode</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libuuid/libuuid/libuuid.vcxproj
+++ b/ZFSin/zfs/lib/libuuid/libuuid/libuuid.vcxproj
@@ -60,7 +60,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libuuid</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libuutil/libuutil/libuutil.vcxproj
+++ b/ZFSin/zfs/lib/libuutil/libuutil/libuutil.vcxproj
@@ -66,7 +66,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libuutil</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libzfs/libzfs/libzfs.vcxproj
+++ b/ZFSin/zfs/lib/libzfs/libzfs/libzfs.vcxproj
@@ -66,7 +66,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libzfs</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libzfs_core/libzfs_core/libzfs_core.vcxproj
+++ b/ZFSin/zfs/lib/libzfs_core/libzfs_core/libzfs_core.vcxproj
@@ -46,7 +46,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libzfs_core</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/libzpool/libzpool/libzpool.vcxproj
+++ b/ZFSin/zfs/lib/libzpool/libzpool/libzpool.vcxproj
@@ -154,7 +154,7 @@
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>
     <RootNamespace>libzpool</RootNamespace>
     <DriverType>KMDF</DriverType>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/ZFSin/zfs/lib/zlib-1.2.3/contrib/vstudio/vc8/zlibstat.vcxproj
+++ b/ZFSin/zfs/lib/zlib-1.2.3/contrib/vstudio/vc8/zlibstat.vcxproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseWithoutAsm|Win32'" Label="Configuration">


### PR DESCRIPTION
The project compiles and runs with Visual Studio 2017. Requiring less step on the VM setup. No hunting down of old VS2015 needed. 

This is more a 'heads' up PR: This might break your current setup. 
So, skip / delay to not interrupt your work flow.
